### PR TITLE
Move gondar.cc into the main app library build target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,7 +139,9 @@ if(WIN32)
   endif()
 
   fix_qt_static_link(app)
-  add_win32_usb_support(app)
+
+  target_link_libraries(app PRIVATE setupapi)
+  target_sources(app PRIVATE src/gondar.cc)
   target_sources(cloudready-usb-maker PRIVATE resources/gondar.rc)
 else()
   target_sources(app PRIVATE src/stubs.cc)

--- a/infra/gondar.cmake
+++ b/infra/gondar.cmake
@@ -31,14 +31,3 @@ function(fix_qt_static_link target)
     ${widgets_extra_LDFLAGS}
     ${freetype_extra_LDFLAGS})
 endfunction()
-
-
-# Build gondar.c with a slightly different set of flags since it's a
-# partially third-party C file. The result is linked to |target| along
-# with any system libs that gondar.c needs.
-function(add_win32_usb_support target)
-  add_library(win32_usb STATIC src/gondar.cc)
-  set_target_properties(win32_usb PROPERTIES CXX_STANDARD 11)
-  target_compile_options(win32_usb PRIVATE ${EXTRA_WARNINGS})
-  target_link_libraries(app PRIVATE win32_usb setupapi)
-endfunction()


### PR DESCRIPTION
It was originally separate so that different compilation flags could
be set on the old `gondar.c`, but that's no longer needed.

This should fix the linker error in https://github.com/neverware/gondar/pull/199