### PR TITLE
move title/subtitle setup into initializepage

### DIFF
--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -258,13 +258,14 @@ int DeviceSelectPage::nextId() const {
 }
 
 WriteOperationPage::WriteOperationPage(QWidget* parent) : WizardPage(parent) {
-  setTitle("Creating your CloudReady USB installer");
-  setSubTitle("This process may take up to 20 minutes.");
   layout.addWidget(&progress);
   setLayout(&layout);
 }
 
 void WriteOperationPage::initializePage() {
+  // set the titles in initializePage for 'make another' flow
+  setTitle("Creating your CloudReady USB installer");
+  setSubTitle("This process may take up to 20 minutes.");
   writeFinished = false;
   // what if we just start writing as soon as we get here
   if (selected_drive == NULL) {


### PR DESCRIPTION
This allows the correct text to be displayed in both the original flow and the 'make another' flow.

addresses OVER-5214

I'm testing this now but looks like it ought to do the trick according to http://doc.qt.io/qt-4.8/qwizardpage.html#initializePage