### PR TITLE
Remove dynamically-allocated QTimer

### DIFF
--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -148,8 +148,6 @@ UsbInsertPage::UsbInsertPage(QWidget* parent) : WizardPage(parent) {
 }
 
 void UsbInsertPage::initializePage() {
-  tim = new QTimer(this);
-  connect(tim, SIGNAL(timeout()), SLOT(getDriveList()));
   // if the page is visited again, delete the old drivelist
   drivelist.clear();
   // send a signal to check for drives
@@ -174,9 +172,10 @@ void UsbInsertPage::getDriveList() {
   }
 
   if (drivelist.empty()) {
-    tim->start(1000);
+    const int second_in_milliseconds = 1000;
+    QTimer::singleShot(second_in_milliseconds, this,
+                       &UsbInsertPage::getDriveList);
   } else {
-    tim->stop();
     showDriveList();
   }
 }

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -62,7 +62,6 @@ class UsbInsertPage : public gondar::WizardPage {
  private:
   void showDriveList();
   QLabel label;
-  QTimer* tim;
   QVBoxLayout layout;
 
  public slots:


### PR DESCRIPTION
We were effectively using it as a singleshot timer anyways.