### PR TITLE
Move ChromeoverLoginPage into GondarWizard::Private

### DIFF
--- a/src/chromeover_login_page.cc
+++ b/src/chromeover_login_page.cc
@@ -48,6 +48,7 @@ ChromeoverLoginPage::ChromeoverLoginPage(QWidget* parent) : WizardPage(parent) {
 }
 
 int ChromeoverLoginPage::nextId() const {
+  const auto& siteList = wizard()->sites();
   if (siteList.size() == 0) {
     return GondarWizard::Page_error;
   } else if (siteList.size() > 1) {
@@ -77,7 +78,7 @@ bool ChromeoverLoginPage::validatePage() {
 
 void ChromeoverLoginPage::handleMeepoFinished() {
   if (meepo_.error().isEmpty()) {
-    siteList = meepo_.sites();
+    wizard()->setSites(meepo_.sites());
 
     // we don't want users to be able to pass through the screen by pressing
     // next while processing.  this will make validatePage pass and immediately

--- a/src/chromeover_login_page.h
+++ b/src/chromeover_login_page.h
@@ -22,7 +22,6 @@
 #include <QLabel>
 #include <QLineEdit>
 
-#include "gondarsite.h"
 #include "meepo.h"
 #include "wizard_page.h"
 
@@ -32,7 +31,6 @@ class ChromeoverLoginPage : public gondar::WizardPage {
  public:
   ChromeoverLoginPage(QWidget* parent = 0);
   int nextId() const override;
-  std::vector<GondarSite> siteList;
 
  protected:
   bool validatePage() override;

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -19,6 +19,7 @@
 
 #include "about_dialog.h"
 #include "admin_check_page.h"
+#include "chromeover_login_page.h"
 #include "device_select_page.h"
 #include "error_page.h"
 #include "log.h"
@@ -31,8 +32,11 @@ class GondarWizard::Private {
 
   AdminCheckPage adminCheckPage;
   DeviceSelectPage deviceSelectPage;
+  ChromeoverLoginPage chromeoverLoginPage;
   SiteSelectPage siteSelectPage;
   ErrorPage errorPage;
+
+  std::vector<GondarSite> sites;
 
   QDateTime runTime;
 };
@@ -47,7 +51,7 @@ GondarWizard::GondarWizard(QWidget* parent)
   setPage(Page_adminCheck, &p_->adminCheckPage);
   // chromeoverLogin and imageSelect are alternatives to each other
   // that both progress to usbInsertPage
-  setPage(Page_chromeoverLogin, &chromeoverLoginPage);
+  setPage(Page_chromeoverLogin, &p_->chromeoverLoginPage);
   setPage(Page_siteSelect, &p_->siteSelectPage);
   setPage(Page_imageSelect, &imageSelectPage);
   setPage(Page_usbInsert, &usbInsertPage);
@@ -89,6 +93,15 @@ void GondarWizard::setMakeAnotherLayout() {
                 << QWizard::FinishButton;
   setButtonLayout(button_layout);
 }
+
+const std::vector<GondarSite>& GondarWizard::sites() const {
+  return p_->sites;
+}
+
+void GondarWizard::setSites(const std::vector<GondarSite>& sites) {
+  p_->sites = sites;
+}
+
 // handle event when 'make another usb' button pressed
 void GondarWizard::handleCustomButton(int buttonIndex) {
   if (buttonIndex == QWizard::CustomButton1) {

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -17,12 +17,12 @@
 #define GONDARWIZARD_H
 
 #include <memory>
+#include <vector>
 
 #include <QShortcut>
 #include <QString>
 #include <QWizard>
 
-#include "chromeover_login_page.h"
 #include "download_progress_page.h"
 #include "image_select_page.h"
 #include "usb_insert_page.h"
@@ -32,6 +32,8 @@ class QCheckBox;
 class QGroupBox;
 class QLabel;
 class QRadioButton;
+
+class GondarSite;
 
 class GondarWizard : public QWizard {
   Q_OBJECT
@@ -50,11 +52,13 @@ class GondarWizard : public QWizard {
   // some data types and convoluted for others.  In this case, a later page
   // makes a decision based on a radio button seleciton in an earlier page,
   // so putting the shared state in the wizard seems more straightforward
-  ChromeoverLoginPage chromeoverLoginPage;
   ImageSelectPage imageSelectPage;
   DownloadProgressPage downloadProgressPage;
   UsbInsertPage usbInsertPage;
   WriteOperationPage writeOperationPage;
+
+  const std::vector<GondarSite>& sites() const;
+  void setSites(const std::vector<GondarSite>& sites);
 
   // this enum determines page order
   enum {

--- a/src/site_select_page.cc
+++ b/src/site_select_page.cc
@@ -41,7 +41,7 @@ SiteSelectPage::SiteSelectPage(QWidget* parent) : WizardPage(parent) {
 }
 
 void SiteSelectPage::initializePage() {
-  const auto& sitesList = wizard()->chromeoverLoginPage.siteList;
+  const auto& sitesList = wizard()->sites();
   for (const auto& site : sitesList) {
     auto* curButton = new SiteButton(site);
     sitesButtons.addButton(curButton);


### PR DESCRIPTION
Moved the sites list out of the login page and up to GondarWizard so
that it can be shared with the SiteSelectPage.