### PR TITLE
Use C++11-style Qt connections

### DIFF
--- a/src/download_progress_page.cc
+++ b/src/download_progress_page.cc
@@ -30,9 +30,11 @@ void DownloadProgressPage::initializePage() {
   setLayout(&layout);
   const QUrl url = wizard()->imageSelectPage.getUrl();
   qDebug() << "using url= " << url;
-  connect(&manager, SIGNAL(finished()), this, SLOT(markComplete()));
+  connect(&manager, &DownloadManager::finished, this,
+          &DownloadProgressPage::markComplete);
   manager.append(url.toString());
-  connect(&manager, SIGNAL(started()), this, SLOT(onDownloadStarted()));
+  connect(&manager, &DownloadManager::started, this,
+          &DownloadProgressPage::onDownloadStarted);
 }
 
 void DownloadProgressPage::onDownloadStarted() {
@@ -54,7 +56,8 @@ void DownloadProgressPage::markComplete() {
   // now that the download is finished, let's unzip the build.
   notifyUnzip();
   unzipThread = new UnzipThread(manager.outputFileInfo(), this);
-  connect(unzipThread, SIGNAL(finished()), this, SLOT(onUnzipFinished()));
+  connect(unzipThread, &UnzipThread::finished, this,
+          &DownloadProgressPage::onUnzipFinished);
   unzipThread->start();
 }
 

--- a/src/downloader.cc
+++ b/src/downloader.cc
@@ -35,12 +35,12 @@ void DownloadManager::append(const QStringList& urlList) {
     append(QUrl::fromEncoded(url.toLocal8Bit()));
 
   if (downloadQueue.isEmpty())
-    QTimer::singleShot(0, this, SIGNAL(finished()));
+    QTimer::singleShot(0, this, &DownloadManager::finished);
 }
 
 void DownloadManager::append(const QUrl& url) {
   if (downloadQueue.isEmpty())
-    QTimer::singleShot(0, this, SLOT(startNextDownload()));
+    QTimer::singleShot(0, this, &DownloadManager::startNextDownload);
 
   downloadQueue.enqueue(url);
   ++totalCount;
@@ -77,8 +77,10 @@ void DownloadManager::startNextDownload() {
   QNetworkRequest request(url);
   gondar::SendMetric(gondar::Metric::DownloadAttempt);
   currentDownload = manager.get(request);
-  connect(currentDownload, SIGNAL(finished()), SLOT(downloadFinished()));
-  connect(currentDownload, SIGNAL(readyRead()), SLOT(downloadReadyRead()));
+  connect(currentDownload, &QNetworkReply::finished, this,
+          &DownloadManager::downloadFinished);
+  connect(currentDownload, &QNetworkReply::readyRead, this,
+          &DownloadManager::downloadReadyRead);
   emit started();
 
   // prepare the output

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -71,8 +71,8 @@ GondarWizard::GondarWizard(QWidget* parent)
 
   connect(&about_shortcut_, &QShortcut::activated, &p_->aboutDialog,
           &gondar::AboutDialog::show);
-  connect(this, SIGNAL(customButtonClicked(int)), this,
-          SLOT(handleCustomButton(int)));
+  connect(this, &GondarWizard::customButtonClicked, this,
+          &GondarWizard::handleCustomButton);
 
   p_->runTime = QDateTime::currentDateTime();
 }

--- a/src/usb_insert_page.cc
+++ b/src/usb_insert_page.cc
@@ -37,7 +37,8 @@ UsbInsertPage::UsbInsertPage(QWidget* parent) : WizardPage(parent) {
   setLayout(&layout);
 
   // the next button should be grayed out until the user inserts a USB
-  connect(this, SIGNAL(driveListRequested()), this, SLOT(getDriveList()));
+  connect(this, &UsbInsertPage::driveListRequested, this,
+          &UsbInsertPage::getDriveList);
 }
 
 const DeviceGuyList& UsbInsertPage::devices() const {

--- a/src/write_operation_page.cc
+++ b/src/write_operation_page.cc
@@ -52,7 +52,8 @@ void WriteOperationPage::writeToDrive() {
   image_path.append(wizard()->downloadProgressPage.getImageFileName());
   showProgress();
   diskWriteThread = new DiskWriteThread(&device, image_path, this);
-  connect(diskWriteThread, SIGNAL(finished()), this, SLOT(onDoneWriting()));
+  connect(diskWriteThread, &DiskWriteThread::finished, this,
+          &WriteOperationPage::onDoneWriting);
   LOG_INFO << "launching thread...";
   gondar::SendMetric(gondar::Metric::UsbAttempt);
   diskWriteThread->start();


### PR DESCRIPTION
Replaces SIGNAL() and SLOT() macros with member function
pointers. This helps by surfacing some errors at compile time instead
of runtime.