### PR TITLE
logging: specialize QUrl for easier logging

### DIFF
--- a/src/downloader.cc
+++ b/src/downloader.cc
@@ -69,7 +69,7 @@ void DownloadManager::startNextDownload() {
 
   if (!output.open(QIODevice::WriteOnly)) {
     LOG_ERROR << "failed to open " << filename << ": " << output.errorString();
-    LOG_ERROR << "skipping download of " << url.toString();
+    LOG_ERROR << "skipping download of " << url;
     startNextDownload();
     return;  // skip this download
   }
@@ -84,7 +84,7 @@ void DownloadManager::startNextDownload() {
   emit started();
 
   // prepare the output
-  LOG_INFO << "downloading " << url.toString();
+  LOG_INFO << "downloading " << url;
   downloadTime.start();
 }
 

--- a/src/log.cc
+++ b/src/log.cc
@@ -28,6 +28,11 @@ namespace plog {
 void operator<<(util::nstringstream& stream, const DeviceGuy& device) {
   stream << device.toString().c_str();
 }
+
+void operator<<(util::nstringstream& stream, const QUrl& url) {
+  const auto bytes = url.toString().toUtf8();
+  stream << bytes.data();
+}
 }  // namespace plog
 
 namespace gondar {

--- a/src/log.h
+++ b/src/log.h
@@ -16,9 +16,10 @@
 #ifndef LOG_H
 #define LOG_H
 
-// Qt header first to ensure that the plog internal ifdefs enable Qt
+// Qt headers first to ensure that the plog internal ifdefs enable Qt
 // support
 #include <QString>
+#include <QUrl>
 
 #include "plog/Log.h"
 
@@ -26,6 +27,7 @@ class DeviceGuy;
 
 namespace plog {
 void operator<<(util::nstringstream& stream, const DeviceGuy& device);
+void operator<<(util::nstringstream& stream, const QUrl& url);
 }  // namespace plog
 
 namespace gondar {

--- a/src/newest_image_url.cc
+++ b/src/newest_image_url.cc
@@ -50,7 +50,7 @@ void NewestImageUrl::handleReply(QNetworkReply* reply) {
   } else {
     sixtyFourUrl = url;
   }
-  LOG_INFO << "using latest url: " << url.toString();
+  LOG_INFO << "using latest url: " << url;
   reply->deleteLater();
 }
 


### PR DESCRIPTION
This allows logging of a `QUrl` without calling `toString()`.
