### PR TITLE
Chromeover flow now shows build from all products

### DIFF
--- a/src/chromeover_login_page.cc
+++ b/src/chromeover_login_page.cc
@@ -55,9 +55,7 @@ int ChromeoverLoginPage::nextId() const {
     // if there are multiple sites, we'll set the urls on the site select page
     return GondarWizard::Page_siteSelect;
   } else {
-    // otherwise, we can skip that step and update the urls here
-    wizard()->imageSelectPage.set64Url(siteList[0].get64Url());
-    wizard()->imageSelectPage.set32Url(siteList[0].get32Url());
+    wizard()->imageSelectPage.addImages(siteList[0].getImages());
     return GondarWizard::Page_imageSelect;
   }
 }

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -20,11 +20,10 @@ class GondarImage {
   public:
     GondarImage() {
     }
-    GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) {
-        this->product = productIn;
-        this->imageName = imageNameIn;
-        this->url = urlIn;
-    }
+    GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) : 
+        product(productIn), 
+        imageName(imageNameIn),
+        url(urlIn) { }
     QString getCompositeName() {
         return product + " " + imageName;
     }

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -1,3 +1,17 @@
+// Copyright 2017 Neverware
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 #ifndef GONDARIMAGE_H
 #define GONDARIMAGE_H

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -1,0 +1,31 @@
+
+#ifndef GONDARIMAGE_H
+#define GONDARIMAGE_H
+
+class GondarImage {
+  public:
+    GondarImage() {
+        this->product = QString("UHOH");
+        this->imageName = QString("OHDEAR");
+        this->url = QUrl();
+    }
+    GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) {
+        this->product = productIn;
+        this->imageName = imageNameIn;
+        this->url = urlIn;
+    }
+    QString getCompositeName() {
+        return product + " " + imageName;
+    }
+    bool is32Bit() {
+        return imageName.contains("32-bit", Qt::CaseInsensitive);
+    }
+    bool isDeployable() {
+        return imageName.contains("deployable", Qt::CaseInsensitive);
+    }
+    QString product;
+    QString imageName;
+    QUrl url;
+};
+
+#endif

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -17,25 +17,18 @@
 #define GONDARIMAGE_H
 
 class GondarImage {
-  public:
-    GondarImage() {
-    }
-    GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) : 
-        product(productIn), 
-        imageName(imageNameIn),
-        url(urlIn) { }
-    QString getCompositeName() {
-        return product + " " + imageName;
-    }
-    bool is32Bit() {
-        return imageName.contains("32-bit", Qt::CaseInsensitive);
-    }
-    bool isDeployable() {
-        return imageName.contains("deployable", Qt::CaseInsensitive);
-    }
-    QString product;
-    QString imageName;
-    QUrl url;
+ public:
+  GondarImage() {}
+  GondarImage(QString productIn, QString imageNameIn, QUrl urlIn)
+      : product(productIn), imageName(imageNameIn), url(urlIn) {}
+  QString getCompositeName() { return product + " " + imageName; }
+  bool is32Bit() { return imageName.contains("32-bit", Qt::CaseInsensitive); }
+  bool isDeployable() {
+    return imageName.contains("deployable", Qt::CaseInsensitive);
+  }
+  QString product;
+  QString imageName;
+  QUrl url;
 };
 
 #endif

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -5,8 +5,8 @@
 class GondarImage {
   public:
     GondarImage() {
-        this->product = QString("UHOH");
-        this->imageName = QString("OHDEAR");
+        this->product = QString("");
+        this->imageName = QString("");
         this->url = QUrl();
     }
     GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) {

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -19,9 +19,6 @@
 class GondarImage {
   public:
     GondarImage() {
-        this->product = QString("");
-        this->imageName = QString("");
-        this->url = QUrl();
     }
     GondarImage(QString productIn, QString imageNameIn, QUrl urlIn) {
         this->product = productIn;

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -22,8 +22,8 @@ class GondarImage {
   GondarImage(QString productIn, QString imageNameIn, QUrl urlIn)
       : product(productIn), imageName(imageNameIn), url(urlIn) {}
   QString getCompositeName() { return product + " " + imageName; }
-  bool is32Bit() { return imageName.contains("32-bit", Qt::CaseInsensitive); }
-  bool isDeployable() {
+  bool is32Bit() const { return imageName.contains("32-bit", Qt::CaseInsensitive); }
+  bool isDeployable() const {
     return imageName.contains("deployable", Qt::CaseInsensitive);
   }
   QString product;

--- a/src/gondarsite.cc
+++ b/src/gondarsite.cc
@@ -32,7 +32,6 @@ const QString& GondarSite::getSiteName() const {
 QList<GondarImage> GondarSite::getImages() const {
   return imageList;
 }
-void GondarSite::addImage(QString product, QString imageName, QUrl url) {
-  GondarImage image(product, imageName, url);
+void GondarSite::addImage(const GondarImage& image) {
   imageList.append(image);
 }

--- a/src/gondarsite.cc
+++ b/src/gondarsite.cc
@@ -29,18 +29,10 @@ const QString& GondarSite::getSiteName() const {
   return siteName;
 }
 
-void GondarSite::set32Url(QUrl url) {
-  url32 = url;
+QList<GondarImage> GondarSite::getImages() const {
+  return imageList;
 }
-
-void GondarSite::set64Url(QUrl url) {
-  url64 = url;
-}
-
-QUrl GondarSite::get32Url() const {
-  return url32;
-}
-
-QUrl GondarSite::get64Url() const {
-  return url64;
+void GondarSite::addImage(QString product, QString imageName, QUrl url) {
+  GondarImage image(product, imageName, url);
+  imageList.append(image);
 }

--- a/src/gondarsite.h
+++ b/src/gondarsite.h
@@ -27,7 +27,7 @@ class GondarSite {
   int getSiteId() const;
   const QString& getSiteName() const;
   QList<GondarImage> getImages() const;
-  void addImage(QString product, QString imageName, QUrl url);
+  void addImage(const GondarImage& image);
 
  private:
   int siteId;

--- a/src/gondarsite.h
+++ b/src/gondarsite.h
@@ -19,19 +19,20 @@
 #include <QString>
 #include <QUrl>
 
+#include "gondarimage.h"
+
 class GondarSite {
  public:
   GondarSite(int siteIdIn, QString siteNameIn);
   int getSiteId() const;
   const QString& getSiteName() const;
-  void set32Url(QUrl url);
-  void set64Url(QUrl url);
-  QUrl get32Url() const;
-  QUrl get64Url() const;
+  QList<GondarImage> getImages() const;
+  void addImage(QString product, QString imageName, QUrl url);
 
  private:
   int siteId;
   QString siteName;
+  QList<GondarImage> imageList;
   QUrl url32;
   QUrl url64;
 };

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -89,7 +89,6 @@ void ImageSelectPage::addImage(GondarImage image) {
   if (image.isDeployable()) {
     return;
   }
-  // FIXME: leak
   DownloadButton* newButton = new DownloadButton(image.url);
   newButton->setText(image.getCompositeName());
   bitnessButtons.addButton(newButton);

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -23,7 +23,7 @@
 
 class DownloadButton : public QRadioButton {
  public:
-  DownloadButton(QUrl& url_in) : url(url_in) { }
+  DownloadButton(QUrl& url_in) : url(url_in) {}
   QUrl getUrl() const { return url; }
 
  private:
@@ -35,7 +35,9 @@ ImageSelectPage::ImageSelectPage(QWidget* parent) : WizardPage(parent) {
   setSubTitle(" ");
 
   thirtyTwo.setText("32-bit");
-  thirtyTwoDetails.setText("<a href=\"https://guide.neverware.com/supported-devices\">Only intended for certified models marked '32-bit Only'</a>");
+  thirtyTwoDetails.setText(
+      "<a href=\"https://guide.neverware.com/supported-devices\">Only intended "
+      "for certified models marked '32-bit Only'</a>");
   thirtyTwoDetails.setTextFormat(Qt::RichText);
   thirtyTwoDetails.setTextInteractionFlags(Qt::TextBrowserInteraction);
   thirtyTwoDetails.setOpenExternalLinks(true);
@@ -88,7 +90,7 @@ void ImageSelectPage::addImage(GondarImage image) {
     return;
   }
   // FIXME: leak
-  DownloadButton * newButton = new DownloadButton(image.url);
+  DownloadButton* newButton = new DownloadButton(image.url);
   newButton->setText(image.getCompositeName());
   bitnessButtons.addButton(newButton);
   layout.addWidget(newButton);
@@ -99,14 +101,14 @@ void ImageSelectPage::addImage(GondarImage image) {
 
 void ImageSelectPage::addImages(QList<GondarImage> images) {
   GondarImage curImage;
-  foreach(curImage, images) {
+  foreach (curImage, images) {
     // FIXME: 32-bit images should be last.  For the time being, this must be
     // handled on the Gondar side.
     if (!curImage.is32Bit()) {
       addImage(curImage);
     }
   }
-  foreach(curImage, images) {
+  foreach (curImage, images) {
     if (curImage.is32Bit()) {
       addImage(curImage);
     }
@@ -118,8 +120,8 @@ QUrl ImageSelectPage::getUrl() {
   QAbstractButton* selected = bitnessButtons.checkedButton();
   if (gondar::isChromeover()) {
     // for chromeover, use the download button's url attribute
-    DownloadButton * selected_download_button =
-        dynamic_cast<DownloadButton *>(selected);
+    DownloadButton* selected_download_button =
+        dynamic_cast<DownloadButton*>(selected);
     return selected_download_button->getUrl();
   } else {
     // for beerover, we had to wait on a url lookup and we consult newestImage

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -99,15 +99,14 @@ void ImageSelectPage::addImage(GondarImage image) {
 }
 
 void ImageSelectPage::addImages(QList<GondarImage> images) {
-  GondarImage curImage;
-  foreach (curImage, images) {
+  for (const auto& curImage : images) {
     // FIXME: 32-bit images should be last.  For the time being, this must be
     // handled on the Gondar side.
     if (!curImage.is32Bit()) {
       addImage(curImage);
     }
   }
-  foreach (curImage, images) {
+  for (const auto& curImage : images) {
     if (curImage.is32Bit()) {
       addImage(curImage);
     }

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -15,28 +15,42 @@
 
 #include "image_select_page.h"
 
+#include "gondarimage.h"
+
 #include "gondarwizard.h"
 #include "log.h"
 #include "util.h"
 
+class DownloadButton : public QRadioButton {
+ public:
+  DownloadButton(QUrl& url_in) : url(url_in) { }
+  QUrl getUrl() const { return url; }
+
+ private:
+  QUrl url;
+};
+
 ImageSelectPage::ImageSelectPage(QWidget* parent) : WizardPage(parent) {
   setTitle("Which version of CloudReady do you need?");
-  setSubTitle("Choose between 32-bit and 64-bit installers");
-
-  sixtyFourDetails.setText("Suitable for most computers made after 2007");
-  thirtyTwoDetails.setText(
-      "For older computers or devices with Intel Atom CPUs");
+  setSubTitle(" ");
 
   thirtyTwo.setText("32-bit");
-  sixtyFour.setText("64-bit (recommended)");
-  sixtyFour.setChecked(true);
-  bitnessButtons.addButton(&thirtyTwo);
-  bitnessButtons.addButton(&sixtyFour);
-
-  layout.addWidget(&sixtyFour);
-  layout.addWidget(&sixtyFourDetails);
-  layout.addWidget(&thirtyTwo);
-  layout.addWidget(&thirtyTwoDetails);
+  thirtyTwoDetails.setText("<a href=\"https://guide.neverware.com/supported-devices\">Only intended for certified models marked '32-bit Only'</a>");
+  thirtyTwoDetails.setTextFormat(Qt::RichText);
+  thirtyTwoDetails.setTextInteractionFlags(Qt::TextBrowserInteraction);
+  thirtyTwoDetails.setOpenExternalLinks(true);
+  // we use these buttons for beerover only now
+  if (!gondar::isChromeover()) {
+    sixtyFourDetails.setText("Suitable for most computers made after 2007");
+    sixtyFour.setText("64-bit (recommended)");
+    sixtyFour.setChecked(true);
+    bitnessButtons.addButton(&thirtyTwo);
+    bitnessButtons.addButton(&sixtyFour);
+    layout.addWidget(&sixtyFour);
+    layout.addWidget(&sixtyFourDetails);
+    layout.addWidget(&thirtyTwo);
+    layout.addWidget(&thirtyTwoDetails);
+  }
 
   setLayout(&layout);
   connect(&newestImageUrl, &NewestImageUrl::errorOccurred, this,
@@ -68,23 +82,55 @@ int ImageSelectPage::nextId() const {
   return GondarWizard::Page_usbInsert;
 }
 
-void ImageSelectPage::set32Url(QUrl url_in) {
-  newestImageUrl.set32Url(url_in);
+void ImageSelectPage::addImage(GondarImage image) {
+  // do not list deployable images
+  if (image.isDeployable()) {
+    return;
+  }
+  // FIXME: leak
+  DownloadButton * newButton = new DownloadButton(image.url);
+  newButton->setText(image.getCompositeName());
+  bitnessButtons.addButton(newButton);
+  layout.addWidget(newButton);
+  if (image.is32Bit()) {
+    layout.addWidget(&thirtyTwoDetails);
+  }
 }
 
-void ImageSelectPage::set64Url(QUrl url_in) {
-  newestImageUrl.set64Url(url_in);
+void ImageSelectPage::addImages(QList<GondarImage> images) {
+  GondarImage curImage;
+  foreach(curImage, images) {
+    // FIXME: 32-bit images should be last.  For the time being, this must be
+    // handled on the Gondar side.
+    if (!curImage.is32Bit()) {
+      addImage(curImage);
+    }
+  }
+  foreach(curImage, images) {
+    if (curImage.is32Bit()) {
+      addImage(curImage);
+    }
+  }
 }
 
+// this is what is used later in the wizard to find what url should be used
 QUrl ImageSelectPage::getUrl() {
   QAbstractButton* selected = bitnessButtons.checkedButton();
-  if (selected == &thirtyTwo) {
-    return newestImageUrl.get32Url();
-  } else if (selected == &sixtyFour) {
-    return newestImageUrl.get64Url();
+  if (gondar::isChromeover()) {
+    // for chromeover, use the download button's url attribute
+    DownloadButton * selected_download_button =
+        dynamic_cast<DownloadButton *>(selected);
+    return selected_download_button->getUrl();
   } else {
-    // TODO: decide what this behavior should be
-    return newestImageUrl.get64Url();
+    // for beerover, we had to wait on a url lookup and we consult newestImage
+    if (selected == &thirtyTwo) {
+      return newestImageUrl.get32Url();
+    } else if (selected == &sixtyFour) {
+      return newestImageUrl.get64Url();
+    } else {
+      // TODO: decide what this behavior should be
+      return newestImageUrl.get64Url();
+    }
   }
 }
 

--- a/src/image_select_page.h
+++ b/src/image_select_page.h
@@ -26,6 +26,8 @@
 
 #include "wizard_page.h"
 
+#include "gondarimage.h"
+
 class ImageSelectPage : public gondar::WizardPage {
   Q_OBJECT
 
@@ -33,8 +35,8 @@ class ImageSelectPage : public gondar::WizardPage {
   ImageSelectPage(QWidget* parent = 0);
   QUrl getUrl() const;
   int nextId() const override;
-  void set32Url(QUrl url_in);
-  void set64Url(QUrl url_in);
+  void addImage(GondarImage image);
+  void addImages(QList<GondarImage> images);
   QUrl getUrl();
   void handleNewestImageUrlError();
 

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -216,7 +216,8 @@ void Meepo::handleDownloadsReply(QNetworkReply* reply) {
       QJsonObject curImage = productArray[i].toObject();
       QString curImageName(curImage["title"].toString());
       QUrl curUrl(curImage["url"].toString());
-      site->addImage(curProduct, curImageName, curUrl);
+      GondarImage gondarImage(curProduct, curImageName, curUrl);
+      site->addImage(gondarImage);
     }
     productItr++;
   }

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -208,18 +208,15 @@ void Meepo::handleDownloadsReply(QNetworkReply* reply) {
   const auto jsonObj = jsonFromReply(reply);
   QJsonObject productsObj = jsonObj["links"].toObject();
 
-  int productItr = 0;
-  for (QJsonValueRef product : productsObj) {
-    QJsonArray productArray = product.toArray();
-    QString curProduct = productsObj.keys().at(productItr);
-    for (int i = 0; i < productArray.size(); i++) {
-      QJsonObject curImage = productArray[i].toObject();
-      QString curImageName(curImage["title"].toString());
-      QUrl curUrl(curImage["url"].toString());
-      GondarImage gondarImage(curProduct, curImageName, curUrl);
+  for (const auto& product : productsObj.keys()) {
+    for (const auto& image : productsObj[product].toArray()) {
+      const auto imageObj = image.toObject();
+      const auto imageName(imageObj["title"].toString());
+      const QUrl url(imageObj["url"].toString());
+      LOG_INFO << "Product: " << product << ", Image name:" << imageName;
+      GondarImage gondarImage(product, imageName, url);
       site->addImage(gondarImage);
     }
-    productItr++;
   }
   sites_remaining_--;
 

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -207,8 +207,6 @@ void Meepo::handleDownloadsReply(QNetworkReply* reply) {
 
   const auto jsonObj = jsonFromReply(reply);
   QJsonObject productsObj = jsonObj["links"].toObject();
-  QJsonDocument doc(productsObj);
-  QString productsStr(doc.toJson(QJsonDocument::Compact));
 
   int productItr = 0;
   for (QJsonValueRef product : productsObj) {

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -207,22 +207,22 @@ void Meepo::handleDownloadsReply(QNetworkReply* reply) {
   }
 
   const auto jsonObj = jsonFromReply(reply);
-  QJsonObject downloadsObj = jsonObj["links"].toObject();
-  // for starters, let's just use use the cloudready product
-  QJsonValue downloadsValue = downloadsObj["CloudReady"];
-  QJsonArray downloadsArray = downloadsValue.toArray();
-  // for starters, let's just use "32-bit" and "64-bit" builds
-  for (int i = 0; i < downloadsArray.size(); i++) {
-    QJsonObject download = downloadsArray.at(i).toObject();
-    if (download["title"] == "64-Bit") {
-      QUrl url64(download["url"].toString());
-      site->set64Url(url64);
-    } else if (download["title"] == "32-Bit") {
-      QUrl url32(download["url"].toString());
-      site->set32Url(url32);
-    }
-  }
+  QJsonObject productsObj = jsonObj["links"].toObject();
+  QJsonDocument doc(productsObj);
+  QString productsStr(doc.toJson(QJsonDocument::Compact));
 
+  int productItr = 0;
+  for (QJsonValueRef product : productsObj) {
+    QJsonArray productArray = product.toArray();
+    QString curProduct = productsObj.keys().at(productItr);
+    for (int i = 0; i < productArray.size(); i++) {
+      QJsonObject curImage = productArray[i].toObject();
+      QString curImageName(curImage["title"].toString());
+      QUrl curUrl(curImage["url"].toString());
+      site->addImage(curProduct, curImageName, curUrl);
+    }
+    productItr++;
+  }
   sites_remaining_--;
 
   // see if we're done

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -75,8 +75,7 @@ int siteIdFromUrl(const QUrl& url) {
 QNetworkRequest createAuthRequest() {
   auto url = createUrl(path_auth);
   QNetworkRequest request(url);
-  request.setHeader(QNetworkRequest::ContentTypeHeader,
-                    "application/json");
+  request.setHeader(QNetworkRequest::ContentTypeHeader, "application/json");
   return request;
 }
 

--- a/src/site_select_page.cc
+++ b/src/site_select_page.cc
@@ -57,13 +57,8 @@ bool SiteSelectPage::validatePage() {
     return false;
   } else {
     const auto site = selected->site();
-
-    // if we have a site selected, update our download links for that
-    // go find the sitesList
-    qDebug() << "DEBUG: url64 selected=" << site.get64Url();
-    qDebug() << "DEBUG: url32 selected=" << site.get32Url();
-    wizard()->imageSelectPage.set64Url(site.get64Url());
-    wizard()->imageSelectPage.set32Url(site.get32Url());
+    QList<GondarImage> imageList = site.getImages();
+    wizard()->imageSelectPage.addImages(imageList);
     return true;
   }
 }


### PR DESCRIPTION
Addresses OVER-5337

Distributable images are excluded.  Previous behavior worked well for CloudReady sites, but would not display other products, and would crash if a customer only had VDI or 365 products available.