### PR TITLE
about dialog: use readUtf8File

### DIFF
--- a/src/about_dialog.cc
+++ b/src/about_dialog.cc
@@ -23,26 +23,13 @@
 
 namespace gondar {
 
-namespace {
-
-QString readTextFile(const QString& path) {
-  QFile file(path);
-  if (!file.open(QFile::ReadOnly)) {
-    throw std::runtime_error("error opening file for reading");
-  }
-
-  return QString::fromUtf8(file.readAll());
-}
-
-}  // namespace
-
 AboutDialog::AboutDialog() {
   about_label_.setOpenExternalLinks(true);
   about_label_.setWordWrap(true);
-  about_label_.setText(readTextFile(":/about.html"));
+  about_label_.setText(readUtf8File(":/about.html"));
 
   license_text_browser_.setOpenExternalLinks(true);
-  license_text_browser_.setHtml(readTextFile(":/gpl-3.0-standalone.html"));
+  license_text_browser_.setHtml(readUtf8File(":/gpl-3.0-standalone.html"));
   license_text_browser_.setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
 
   close_button_.setText(tr("&Close"));


### PR DESCRIPTION
This relates to Kendall's work on better integration tests. They are
failing with an exception that didn't give enough information. They
will still fail with this fix, but with a better error message.