### PR TITLE
Swizzard doesn't like 0.0.0 versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ botocore==1.7.17
 docutils==0.14
 futures==3.1.1
 jmespath==0.9.3
-pkg-resources==0.0.0
 python-dateutil==2.6.1
 s3transfer==0.1.11
 six==1.11.0


### PR DESCRIPTION
    * No idea why pip-freeze gave me a 0.0.0 version, but after removing it I
      was able to build environments on both machines and import everything.