### PR TITLE
Kendall 1.9 hotfix 01

### DIFF
--- a/src/gpt_pal.cc
+++ b/src/gpt_pal.cc
@@ -37,8 +37,8 @@ bool clearMbrGpt(const char* physical_path) {
   std::string physical_path_str(physical_path);
   PalData gptdata;
   gptdata.LoadPartitions(std::string(physical_path));
-  // attempt to fix any gpt/mbr problems by setting to a sane, empty state
   int quiet = true;
+  // attempt to fix any gpt/mbr problems by setting to a sane, empty state
   gptdata.SaveGPTData(quiet);
   int problems = gptdata.Verify();
   if (problems > 0) {

--- a/src/gpt_pal.cc
+++ b/src/gpt_pal.cc
@@ -30,7 +30,7 @@ PalData::PalData() : GPTData() { }
 WhichToUse PalData::UseWhichPartitions(void) {
   // The disk may be in a weird state, but we are about to reformat it.
   // Just always use a new partition table.
-  return use_gpt;
+  return use_new;
 }
 
 bool clearMbrGpt(const char* physical_path) {
@@ -38,8 +38,6 @@ bool clearMbrGpt(const char* physical_path) {
   PalData gptdata;
   gptdata.LoadPartitions(std::string(physical_path));
   // attempt to fix any gpt/mbr problems by setting to a sane, empty state
-  gptdata.ClearGPTData();
-  gptdata.MakeProtectiveMBR();
   int quiet = true;
   gptdata.SaveGPTData(quiet);
   int problems = gptdata.Verify();

--- a/src/gpt_pal.cc
+++ b/src/gpt_pal.cc
@@ -18,39 +18,14 @@
 // We use gdisk to clean up the GPT such that Windows is happy writing to
 // the disk
 #include "../gdisk/gpt.h"
-#include "../gdisk/crc32.h"
-#include <stdio.h>
 
 class PalData : public GPTData {
 public:
-  PalData(string filename);
+  PalData();
   WhichToUse UseWhichPartitions(void) override;
 };
 
-PalData::PalData(string filename) {
-    // if we want to call our own copy of UseWhichPartitions()
-   blockSize = SECTOR_SIZE; // set a default
-   diskSize = 0;
-   partitions = NULL;
-   state = gpt_invalid;
-   device = "";
-   justLooking = 0;
-   mainCrcOk = 0;
-   secondCrcOk = 0;
-   mainPartsCrcOk = 0;
-   secondPartsCrcOk = 0;
-   apmFound = 0;
-   bsdFound = 0;
-   sectorAlignment = MIN_AF_ALIGNMENT; // Align partitions on 4096-byte boundaries by default
-   beQuiet = 0;
-   whichWasUsed = use_new;
-   mainHeader.numParts = 0;
-   numParts = 0;
-   // Initialize CRC functions...
-   chksum_crc32gentab();
-   if (!LoadPartitions(filename))
-      exit(2);
-}
+PalData::PalData() : GPTData() { }
 
 WhichToUse PalData::UseWhichPartitions(void) {
   // The disk may be in a weird state, but we are about to reformat it.
@@ -60,7 +35,8 @@ WhichToUse PalData::UseWhichPartitions(void) {
 
 bool clearMbrGpt(const char* physical_path) {
   std::string physical_path_str(physical_path);
-  PalData gptdata(physical_path_str);
+  PalData gptdata;
+  gptdata.LoadPartitions(std::string(physical_path));
   // attempt to fix any gpt/mbr problems by setting to a sane, empty state
   gptdata.ClearGPTData();
   gptdata.MakeProtectiveMBR();

--- a/src/gpt_pal.cc
+++ b/src/gpt_pal.cc
@@ -18,10 +18,49 @@
 // We use gdisk to clean up the GPT such that Windows is happy writing to
 // the disk
 #include "../gdisk/gpt.h"
+#include "../gdisk/crc32.h"
+#include <stdio.h>
+
+class PalData : public GPTData {
+public:
+  PalData(string filename);
+  WhichToUse UseWhichPartitions(void) override;
+};
+
+PalData::PalData(string filename) {
+    // if we want to call our own copy of UseWhichPartitions()
+   blockSize = SECTOR_SIZE; // set a default
+   diskSize = 0;
+   partitions = NULL;
+   state = gpt_invalid;
+   device = "";
+   justLooking = 0;
+   mainCrcOk = 0;
+   secondCrcOk = 0;
+   mainPartsCrcOk = 0;
+   secondPartsCrcOk = 0;
+   apmFound = 0;
+   bsdFound = 0;
+   sectorAlignment = MIN_AF_ALIGNMENT; // Align partitions on 4096-byte boundaries by default
+   beQuiet = 0;
+   whichWasUsed = use_new;
+   mainHeader.numParts = 0;
+   numParts = 0;
+   // Initialize CRC functions...
+   chksum_crc32gentab();
+   if (!LoadPartitions(filename))
+      exit(2);
+}
+
+WhichToUse PalData::UseWhichPartitions(void) {
+  // The disk may be in a weird state, but we are about to reformat it.
+  // Just always use a new partition table.
+  return use_gpt;
+}
 
 bool clearMbrGpt(const char* physical_path) {
   std::string physical_path_str(physical_path);
-  GPTData gptdata(physical_path_str);
+  PalData gptdata(physical_path_str);
   // attempt to fix any gpt/mbr problems by setting to a sane, empty state
   gptdata.ClearGPTData();
   gptdata.MakeProtectiveMBR();

--- a/src/gpt_pal.cc
+++ b/src/gpt_pal.cc
@@ -36,6 +36,7 @@ WhichToUse PalData::UseWhichPartitions(void) {
 bool clearMbrGpt(const char* physical_path) {
   std::string physical_path_str(physical_path);
   PalData gptdata;
+  // set the physical path for this GPT object to act on
   gptdata.LoadPartitions(std::string(physical_path));
   int quiet = true;
   // attempt to fix any gpt/mbr problems by setting to a sane, empty state

--- a/src/util.cc
+++ b/src/util.cc
@@ -62,7 +62,7 @@ QString getDomain() {
 }
 
 QString getGondarVersion() {
-  return QString("1.9");
+  return QString("");
 }
 
 QJsonObject jsonFromReply(QNetworkReply* reply) {


### PR DESCRIPTION
My current solution involves chopper plopperin' the constructor I would like to use, as even though the method I want to override is virtual, calls to it from the parent constructor do not call my child method.