### PR TITLE
Minor code cleanup for slowtest

### DIFF
--- a/src/device_select_page.cc
+++ b/src/device_select_page.cc
@@ -18,13 +18,11 @@
 #include "gondarwizard.h"
 #include "log.h"
 
-DeviceSelectPage::DeviceSelectPage(std::shared_ptr<gondar::DevicePicker> picker_in,
+DeviceSelectPage::DeviceSelectPage(std::unique_ptr<gondar::DevicePicker> picker_in,
                                    QWidget* parent)
-    : WizardPage(parent) {
-  if (!picker_in) {
-    picker = std::make_shared<gondar::DevicePicker>();
-  } else {
-    picker = picker_in;
+    : WizardPage(parent), picker(std::move(picker_in)) {
+  if (!picker) {
+    picker = std::make_unique<gondar::DevicePicker>();
   }
   init();
 }

--- a/src/device_select_page.h
+++ b/src/device_select_page.h
@@ -28,7 +28,7 @@ class DeviceSelectPage : public gondar::WizardPage {
   Q_OBJECT
 
  public:
-  DeviceSelectPage(std::shared_ptr<gondar::DevicePicker> picker_in = 0, QWidget* parent = 0);
+  DeviceSelectPage(std::unique_ptr<gondar::DevicePicker> picker_in, QWidget* parent = 0);
   void init();
   int nextId() const override;
 
@@ -40,7 +40,7 @@ class DeviceSelectPage : public gondar::WizardPage {
  private:
   QVBoxLayout layout;
   QLabel drivesLabel;
-  std::shared_ptr<gondar::DevicePicker> picker;
+  std::unique_ptr<gondar::DevicePicker> picker;
 };
 
 #endif  // SRC_DEVICE_SELECT_PAGE_H_

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -29,11 +29,14 @@
 
 class GondarWizard::Private {
  public:
+  Private(std::unique_ptr<gondar::DevicePicker>&& picker)
+      : deviceSelectPage(std::move(picker)) {}
+
   gondar::UpdateCheck updateCheck;
   gondar::AboutDialog aboutDialog;
 
   AdminCheckPage adminCheckPage;
-  std::unique_ptr<DeviceSelectPage> deviceSelectPage;
+  DeviceSelectPage deviceSelectPage;
   ChromeoverLoginPage chromeoverLoginPage;
   SiteSelectPage siteSelectPage;
   ErrorPage errorPage;
@@ -43,27 +46,11 @@ class GondarWizard::Private {
   QDateTime runTime;
 };
 
-void GondarWizard::initPrivate(std::shared_ptr<gondar::DevicePicker> picker_in) {
-  p_.reset(new Private());
-  if (picker_in) {
-    p_->deviceSelectPage.reset(new DeviceSelectPage(picker_in));
-  } else {
-    p_->deviceSelectPage.reset(new DeviceSelectPage());
-  }
-}
-
-GondarWizard::GondarWizard(QWidget* parent)
-    : QWizard(parent),
-      about_shortcut_(QKeySequence::HelpContents, this) {
-  initPrivate();
-  init();
-}
-
-GondarWizard::GondarWizard(std::shared_ptr<gondar::DevicePicker> picker_in,
+GondarWizard::GondarWizard(std::unique_ptr<gondar::DevicePicker> picker_in,
                            QWidget* parent)
     : QWizard(parent),
+      p_(std::make_unique<Private>(std::move(picker_in))),
       about_shortcut_(QKeySequence::HelpContents, this) {
-  initPrivate(picker_in);
   init();
 }
 void GondarWizard::init() {
@@ -77,7 +64,7 @@ void GondarWizard::init() {
   setPage(Page_siteSelect, &p_->siteSelectPage);
   setPage(Page_imageSelect, &imageSelectPage);
   setPage(Page_usbInsert, &usbInsertPage);
-  setPage(Page_deviceSelect, p_->deviceSelectPage.get());
+  setPage(Page_deviceSelect, &p_->deviceSelectPage);
   setPage(Page_downloadProgress, &downloadProgressPage);
   setPage(Page_writeOperation, &writeOperationPage);
   setPage(Page_error, &p_->errorPage);

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -40,8 +40,7 @@ class GondarWizard : public QWizard {
   Q_OBJECT
 
  public:
-  GondarWizard(QWidget* parent = 0);
-  GondarWizard(std::shared_ptr<gondar::DevicePicker> picker_in,
+  GondarWizard(std::unique_ptr<gondar::DevicePicker> picker_in = nullptr,
                QWidget* parent = 0);
 
   ~GondarWizard();
@@ -81,7 +80,6 @@ class GondarWizard : public QWizard {
   void handleCustomButton(int buttonIndex);
 
  private:
-  void initPrivate(std::shared_ptr<gondar::DevicePicker> picker_in=nullptr);
   class Private;
   std::unique_ptr<Private> p_;
 

--- a/test/slow_test.cc
+++ b/test/slow_test.cc
@@ -69,7 +69,7 @@ void proceed(GondarWizard* wizard, int ms = 500) {
 void Test::testDownloadFlow() {
   initResource();
   gondar::InitializeLogging();
-  GondarWizard wizard(std::make_shared<MockDevicePicker>());
+  GondarWizard wizard(std::make_unique<MockDevicePicker>());
   wizard.show();
   QTest::qWait(1000);
   // 0->3


### PR DESCRIPTION
Changed `std::shared_ptr` to `std::unique_ptr`, removed some duplicate
constructors.