### PR TITLE
change default size to ensure text on final page is legible

### DIFF
--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -86,6 +86,9 @@ void GondarWizard::init() {
   p_->runTime = QDateTime::currentDateTime();
 
   p_->updateCheck.start(this);
+
+  // resize the window (width, height)
+  resize(640, 480);
 }
 
 GondarWizard::~GondarWizard() {}


### PR DESCRIPTION
There are a number of ways to change the default size in Qt (http://doc.qt.io/qt-4.8/qwidget.html#sizePolicy-prop for example).  This is one way.  I haven't tested on windows yet, but on my machine 640 by 400 is enough size, so 640 by 480 is likely enough on windows.