### PR TITLE
Each metric now specifies beerover or chromeover

### DIFF
--- a/src/metric.cc
+++ b/src/metric.cc
@@ -124,6 +124,13 @@ void SendMetric(Metric metric, const std::string& value) {
   if (!version.isEmpty()) {
     json.insert("version", version);
   }
+  QString product;
+  if (gondar::isChromeover()) {
+    product = "chromeover";
+  } else {
+    product = "beerover";
+  }
+  json.insert("product", product);
   QNetworkRequest request(url);
   request.setRawHeader(QByteArray("x-api-key"), api_key);
   request.setHeader(QNetworkRequest::ContentTypeHeader,


### PR DESCRIPTION
Addresses OVER-5619

I've tested this out to make sure metrics propagate for both beerover/chromeover cases correctly.  Note that there remains duplication with the 'beerover-use' and 'chromeover-use' metrics.  That is so we can continue to track the older-style version metrics over time.