### PR TITLE
remove large drive warning

### DIFF
--- a/src/usb_insert_page.cc
+++ b/src/usb_insert_page.cc
@@ -28,7 +28,6 @@ UsbInsertPage::UsbInsertPage(QWidget* parent) : WizardPage(parent) {
 
   label.setText(
       "Sandisk devices are not recommended.  "
-      "USB drives with more than 16Gb of space are not recommended.  "
       "The next screen will become available once a valid "
       "USB drive is inserted.");
   label.setWordWrap(true);


### PR DESCRIPTION
In a meatspace discussion, @smithforrestr and I both agreed large drives should be fine.  People seem to find this warning perplexing https://www.reddit.com/r/cloudready/comments/aauwxx/putting_cloudready_on_32gb_flash_drive/