### PR TITLE
Use classic style instead of modern

### DIFF
--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -90,7 +90,7 @@ void GondarWizard::init() {
   p_->updateCheck.start(this);
 
   // resize the window (width, height)
-  resize(640, 480);
+  resize(800, 600);
 }
 
 GondarWizard::~GondarWizard() {}

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -90,7 +90,7 @@ void GondarWizard::init() {
   p_->updateCheck.start(this);
 
   // resize the window (width, height)
-  resize(800, 600);
+  resize(720, 480);
 }
 
 GondarWizard::~GondarWizard() {}

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -70,7 +70,7 @@ void GondarWizard::init() {
   setPage(Page_downloadProgress, &downloadProgressPage);
   setPage(Page_writeOperation, &writeOperationPage);
   setPage(Page_error, &p_->errorPage);
-  setWizardStyle(QWizard::ModernStyle);
+  setWizardStyle(QWizard::ClassicStyle);
   setWindowTitle(tr("CloudReady USB Maker"));
   setPixmap(QWizard::LogoPixmap, QPixmap(":/images/crlogo.png"));
 


### PR DESCRIPTION
This produces padding for the wizard's pixmap

Addresses OVER-9895

I'll have to double-check on Windows tomorrow but on Linux this resolves the issue.