### PR TITLE
Beerover Gondar should no longer supply 32-bit images: Addresses OVER-11238

### DIFF
--- a/src/admin_check_page.cc
+++ b/src/admin_check_page.cc
@@ -44,6 +44,8 @@ void AdminCheckPage::handleFormatOnly() {
 }
 
 void AdminCheckPage::initializePage() {
+  // get the latest url for beerover if we're in beerover mode
+  wizard()->maybe_fetch();
   is_admin = IsCurrentProcessElevated();
   if (!is_admin) {
     showIsNotAdmin();
@@ -84,6 +86,19 @@ void AdminCheckPage::showIsNotAdmin() {
       "program with sufficient rights.");
 }
 
+bool AdminCheckPage::validatePage() {
+  // if there is an error, we need to allow the user to proceed to the error
+  // screen
+  if (wizard()->getError()) {
+    return true;
+  }
+  if (!gondar::isChromeover()) {
+    // in the beerover case, we need to have retrieved the latest image url
+    return wizard()->newestIsReady();
+  }
+  return true;
+}
+
 int AdminCheckPage::nextId() const {
   if (wizard()->isFormatOnly()) {
     return GondarWizard::Page_usbInsert;
@@ -91,6 +106,6 @@ int AdminCheckPage::nextId() const {
   if (gondar::isChromeover()) {
     return GondarWizard::Page_chromeoverLogin;
   } else {
-    return GondarWizard::Page_imageSelect;
+    return GondarWizard::Page_usbInsert;
   }
 }

--- a/src/admin_check_page.cc
+++ b/src/admin_check_page.cc
@@ -89,7 +89,7 @@ void AdminCheckPage::showIsNotAdmin() {
 bool AdminCheckPage::validatePage() {
   // if there is an error, we need to allow the user to proceed to the error
   // screen
-  if (wizard()->getError()) {
+  if (wizard()->getSessionError()) {
     return true;
   }
   if (!gondar::isChromeover()) {

--- a/src/admin_check_page.h
+++ b/src/admin_check_page.h
@@ -34,6 +34,7 @@ class AdminCheckPage : public gondar::WizardPage {
   bool isComplete() const override;
   void showIsAdmin();
   void showIsNotAdmin();
+  bool validatePage() override;
 
  private:
   QLabel label;

--- a/src/gondarimage.h
+++ b/src/gondarimage.h
@@ -22,9 +22,6 @@ class GondarImage {
   GondarImage(QString productIn, QString imageNameIn, QUrl urlIn)
       : product(productIn), imageName(imageNameIn), url(urlIn) {}
   QString getCompositeName() { return product + " " + imageName; }
-  bool is32Bit() const {
-    return imageName.contains("32-bit", Qt::CaseInsensitive);
-  }
   bool isDeployable() const {
     return imageName.contains("deployable", Qt::CaseInsensitive);
   }

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -56,6 +56,8 @@ GondarWizard::GondarWizard(std::unique_ptr<gondar::DevicePicker> picker_in,
 }
 
 void GondarWizard::init() {
+  // set shared error state to false
+  session_error = false;
   // these pages are automatically cleaned up
   // new instances are made whenever navigation moves on to another page
   // according to qt docs
@@ -84,6 +86,10 @@ void GondarWizard::init() {
           &gondar::AboutDialog::show);
   connect(this, &GondarWizard::customButtonClicked, this,
           &GondarWizard::handleCustomButton);
+  // appropriately move to error screen if there is a problem getting
+  // latest beerover url
+  connect(&newestImageUrl, &NewestImageUrl::errorOccurred, this,
+          &GondarWizard::handleNewestImageUrlError);
 
   p_->runTime = QDateTime::currentDateTime();
 
@@ -145,6 +151,7 @@ int GondarWizard::nextId() const {
 }
 
 void GondarWizard::postError(const QString& error) {
+  setError(true);
   QTimer::singleShot(0, this, [=]() { catchError(error); });
 }
 
@@ -158,4 +165,28 @@ void GondarWizard::catchError(const QString& error) {
 
 qint64 GondarWizard::getRunTime() {
   return p_->runTime.secsTo(QDateTime::currentDateTime());
+}
+
+bool GondarWizard::getError() {
+  return session_error;
+}
+
+void GondarWizard::setError(bool error_in) {
+  session_error = error_in;
+}
+
+// if beerover, start the requisite image fetching
+void GondarWizard::maybe_fetch() {
+  if (!gondar::isChromeover()) {
+    // for beerover, we'll have to check what the latest release is
+    newestImageUrl.fetch();
+  }
+}
+
+bool GondarWizard::newestIsReady() {
+  return newestImageUrl.isReady();
+}
+
+void GondarWizard::handleNewestImageUrlError() {
+  postError("An error has occurred fetching the latest image");
 }

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -151,7 +151,7 @@ int GondarWizard::nextId() const {
 }
 
 void GondarWizard::postError(const QString& error) {
-  setError(true);
+  setSessionError(true);
   QTimer::singleShot(0, this, [=]() { catchError(error); });
 }
 
@@ -167,11 +167,13 @@ qint64 GondarWizard::getRunTime() {
   return p_->runTime.secsTo(QDateTime::currentDateTime());
 }
 
-bool GondarWizard::getError() {
+bool GondarWizard::getSessionError() {
   return session_error;
 }
 
-void GondarWizard::setError(bool error_in) {
+// set wizard-wide error bool so pages with validate page functions
+// can pass through
+void GondarWizard::setSessionError(bool error_in) {
   session_error = error_in;
 }
 

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -26,6 +26,7 @@
 #include "device_picker.h"
 #include "download_progress_page.h"
 #include "image_select_page.h"
+#include "newest_image_url.h"
 #include "usb_insert_page.h"
 #include "write_operation_page.h"
 
@@ -59,11 +60,17 @@ class GondarWizard : public QWizard {
   DownloadProgressPage downloadProgressPage;
   UsbInsertPage usbInsertPage;
   WriteOperationPage writeOperationPage;
+  NewestImageUrl newestImageUrl;
 
   const std::vector<GondarSite>& sites() const;
   void setSites(const std::vector<GondarSite>& sites);
   bool isFormatOnly() const { return formatOnly; }
   void setFormatOnly(bool newValue) { formatOnly = newValue; }
+  bool getError();
+  void setError(bool);
+  bool newestIsReady();
+  void maybe_fetch();
+  void handleNewestImageUrlError();
 
   // this enum determines page order
   enum {
@@ -84,6 +91,7 @@ class GondarWizard : public QWizard {
  private:
   class Private;
   std::unique_ptr<Private> p_;
+  bool session_error;
 
   void catchError(const QString& error);
   // Set the button layout appropriate for most pages; no 'make another usb'

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -66,8 +66,8 @@ class GondarWizard : public QWizard {
   void setSites(const std::vector<GondarSite>& sites);
   bool isFormatOnly() const { return formatOnly; }
   void setFormatOnly(bool newValue) { formatOnly = newValue; }
-  bool getError();
-  void setError(bool);
+  bool getSessionError();
+  void setSessionError(bool);
   bool newestIsReady();
   void maybe_fetch();
   void handleNewestImageUrlError();

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -38,12 +38,6 @@ ImageSelectPage::ImageSelectPage(QWidget* parent) : WizardPage(parent) {
 }
 
 bool ImageSelectPage::validatePage() {
-  // if there is an error, we need to allow the user to proceed to the error
-  // screen
-  // TODO(ken): may be superfluous, have to look at chromeover flow again
-  if (wizard()->getError()) {
-    return true;
-  }
   // currently this is only a concern in the chromeover case, but we would
   // be equally worried were this true in either case
   if (!bitnessButtons.checkedButton()) {

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -34,17 +34,6 @@ class DownloadButton : public QRadioButton {
 ImageSelectPage::ImageSelectPage(QWidget* parent) : WizardPage(parent) {
   setTitle("Which version of CloudReady do you need?");
   setSubTitle(" ");
-
-  // we use these buttons for beerover only now
-  if (!gondar::isChromeover()) {
-    sixtyFourDetails.setText("Suitable for most computers made after 2007");
-    sixtyFour.setText("64-bit (recommended)");
-    sixtyFour.setChecked(true);
-    bitnessButtons.addButton(&sixtyFour);
-    layout.addWidget(&sixtyFour);
-    layout.addWidget(&sixtyFourDetails);
-  }
-
   setLayout(&layout);
 }
 

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -93,12 +93,6 @@ QUrl ImageSelectPage::getUrl() {
         dynamic_cast<DownloadButton*>(selected);
     return selected_download_button->getUrl();
   } else {
-    // for beerover, we had to wait on a url lookup and we consult newestImage
-    if (selected == &sixtyFour) {
-      return wizard()->newestImageUrl.get64Url();
-    } else {
-      // TODO(kendall): decide what this behavior should be
-      return wizard()->newestImageUrl.get64Url();
-    }
+    return wizard()->newestImageUrl.get64Url();
   }
 }

--- a/src/image_select_page.cc
+++ b/src/image_select_page.cc
@@ -40,7 +40,7 @@ ImageSelectPage::ImageSelectPage(QWidget* parent) : WizardPage(parent) {
 bool ImageSelectPage::validatePage() {
   // if there is an error, we need to allow the user to proceed to the error
   // screen
-  // TODO(ken): was this handling just for the beerover case?  if so, can remove
+  // TODO(ken): may be superfluous, have to look at chromeover flow again
   if (wizard()->getError()) {
     return true;
   }

--- a/src/image_select_page.h
+++ b/src/image_select_page.h
@@ -22,37 +22,27 @@
 #include <QUrl>
 #include <QVBoxLayout>
 
-#include "newest_image_url.h"
-
-#include "wizard_page.h"
-
 #include "gondarimage.h"
+#include "wizard_page.h"
 
 class ImageSelectPage : public gondar::WizardPage {
   Q_OBJECT
 
  public:
   explicit ImageSelectPage(QWidget* parent = 0);
-  QUrl getUrl() const;
   int nextId() const override;
   void addImage(GondarImage image);
   void addImages(QList<GondarImage> images);
   QUrl getUrl();
-  void handleNewestImageUrlError();
 
  protected:
-  void initializePage() override;
   bool validatePage() override;
 
  private:
   QButtonGroup bitnessButtons;
-  QRadioButton thirtyTwo;
-  QLabel thirtyTwoDetails;
   QRadioButton sixtyFour;
   QLabel sixtyFourDetails;
   QVBoxLayout layout;
-  NewestImageUrl newestImageUrl;
-  bool hasError;
 };
 
 #endif  // SRC_IMAGE_SELECT_PAGE_H_

--- a/src/newest_image_url.cc
+++ b/src/newest_image_url.cc
@@ -33,7 +33,6 @@ void NewestImageUrl::fetch() {
   connect(&networkManager, &QNetworkAccessManager::finished, this,
           &NewestImageUrl::handleReply);
   networkManager.get(QNetworkRequest(QUrl(baseUrl + "latest-stable-64bit")));
-  networkManager.get(QNetworkRequest(QUrl(baseUrl + "latest-stable-32bit")));
 }
 
 void NewestImageUrl::handleReply(QNetworkReply* reply) {
@@ -45,17 +44,9 @@ void NewestImageUrl::handleReply(QNetworkReply* reply) {
   }
   // we find out which request this is a response for
   QUrl url = getLatestUrl(reply);
-  if (reply->url().toString().contains("32bit")) {
-    thirtyTwoUrl = url;
-  } else {
-    sixtyFourUrl = url;
-  }
+  sixtyFourUrl = url;
   LOG_INFO << "using latest url: " << url;
   reply->deleteLater();
-}
-
-void NewestImageUrl::set32Url(const QUrl& url_in) {
-  thirtyTwoUrl = url_in;
 }
 
 void NewestImageUrl::set64Url(const QUrl& url_in) {
@@ -63,15 +54,11 @@ void NewestImageUrl::set64Url(const QUrl& url_in) {
 }
 
 bool NewestImageUrl::isReady() const {
-  if (thirtyTwoUrl.isEmpty() || sixtyFourUrl.isEmpty()) {
+  if (sixtyFourUrl.isEmpty()) {
     return false;
   } else {
     return true;
   }
-}
-
-const QUrl& NewestImageUrl::get32Url() const {
-  return thirtyTwoUrl;
 }
 
 const QUrl& NewestImageUrl::get64Url() const {

--- a/src/newest_image_url.h
+++ b/src/newest_image_url.h
@@ -25,9 +25,7 @@ class NewestImageUrl : public QObject {
  public:
   void fetch();
   bool isReady() const;
-  void set32Url(const QUrl& url_in);
   void set64Url(const QUrl& url_in);
-  const QUrl& get32Url() const;
   const QUrl& get64Url() const;
  signals:
   void errorOccurred();
@@ -37,7 +35,6 @@ class NewestImageUrl : public QObject {
 
  private:
   QNetworkAccessManager networkManager;
-  QUrl thirtyTwoUrl;
   QUrl sixtyFourUrl;
 };
 


### PR DESCRIPTION
Refactors newestImage to belong to the wizard as a whole rather than an individual page now that beerover users are skipping image selection page in its entirety.

Addresses OVER-11238