### PR TITLE
Now send metrics to meepo as well when we have a valid session token: OVER-8821

### DIFF
--- a/src/admin_check_page.cc
+++ b/src/admin_check_page.cc
@@ -30,13 +30,6 @@ AdminCheckPage::AdminCheckPage(QWidget* parent) : WizardPage(parent) {
   layout.addStretch();
   layout.addWidget(&formatLink);
   setLayout(&layout);
-  // TODO(kendall): move isChromeover() out of AdminCheckPage and call these
-  // metrics from a more intuitive context
-  if (gondar::isChromeover()) {
-    gondar::SendMetric(gondar::Metric::ChromeoverUse);
-  } else {
-    gondar::SendMetric(gondar::Metric::BeeroverUse);
-  }
 }
 
 void AdminCheckPage::handleFormatOnly() {
@@ -45,6 +38,13 @@ void AdminCheckPage::handleFormatOnly() {
 }
 
 void AdminCheckPage::initializePage() {
+  // this logic is in initializePage because wizard() is not callable
+  // from the constructor
+  if (gondar::isChromeover()) {
+    gondar::SendMetric(wizard(), gondar::Metric::ChromeoverUse);
+  } else {
+    gondar::SendMetric(wizard(), gondar::Metric::BeeroverUse);
+  }
   // get the latest url for beerover if we're in beerover mode
   wizard()->maybe_fetch();
   is_admin = IsCurrentProcessElevated();

--- a/src/chromeover_login_page.cc
+++ b/src/chromeover_login_page.cc
@@ -109,7 +109,7 @@ int ChromeoverLoginPage::nextId() const {
   } else {
     // populate the current site for metrics now as we'll be skipping the
     // site select page; OVER-11255
-    gondar::SetSiteId(siteList[0].getSiteId());
+    wizard()->setSiteId(siteList[0].getSiteId());
     wizard()->imageSelectPage.addImages(siteList[0].getImages());
     return GondarWizard::Page_imageSelect;
   }

--- a/src/chromeover_login_page.cc
+++ b/src/chromeover_login_page.cc
@@ -73,10 +73,6 @@ ChromeoverLoginPage::ChromeoverLoginPage(QWidget* parent) : WizardPage(parent) {
   // connect events between our members and ourself
   connect(&googleButton, &QPushButton::clicked, &googleFlow,
           &GoogleFlow::handleGoogleSigninPart1);
-  connect(&meepo_, &gondar::Meepo::finished, this,
-          &ChromeoverLoginPage::handleMeepoFinished);
-  connect(&meepo_, &gondar::Meepo::failed, this,
-          &ChromeoverLoginPage::handleMeepoFailed);
   connect(googleFlow.getManager(), &QNetworkAccessManager::finished, this,
           &ChromeoverLoginPage::handleGoogleSigninFinished);
   connect(&googleFlow, &GoogleFlow::errorMiddle, this,
@@ -128,14 +124,14 @@ bool ChromeoverLoginPage::validatePage() {
     return true;
   }
   if (!started) {
-    meepo_.start(auth);
+    wizard()->meepo_.start(auth);
   }
   started = true;
   return false;
 }
 
 void ChromeoverLoginPage::handleMeepoFinished() {
-  wizard()->setSites(meepo_.sites());
+  wizard()->setSites(wizard()->meepo_.sites());
 
   // we don't want users to be able to pass through the screen by pressing
   // next while processing.  this will make validatePage pass and immediately
@@ -149,9 +145,9 @@ void ChromeoverLoginPage::handleMeepoFinished() {
 void ChromeoverLoginPage::handleMeepoFailed(bool using_google) {
   // If the user has no sites, proceed to the error screen with the
   // appropriate error
-  if (meepo_.no_sites_error == meepo_.error()) {
+  if (wizard()->meepo_.no_sites_error == wizard()->meepo_.error()) {
     finished = true;
-    wizard()->postError(meepo_.no_sites_error);
+    wizard()->postError(wizard()->meepo_.no_sites_error);
     // otherwise, assume login credentials are incorrect and prompt them to
     // retry
   } else {
@@ -173,7 +169,7 @@ void ChromeoverLoginPage::handleGoogleSigninFinished(QNetworkReply* reply) {
   meanWordsLabel.setVisible(false);
   QString id_token = gondar::jsonFromReply(reply)["id_token"].toString();
   if (!started) {
-    meepo_.startGoogle(id_token);
+    wizard()->meepo_.startGoogle(id_token);
     started = true;
   }
 }

--- a/src/chromeover_login_page.h
+++ b/src/chromeover_login_page.h
@@ -34,6 +34,9 @@ class ChromeoverLoginPage : public gondar::WizardPage {
  public:
   explicit ChromeoverLoginPage(QWidget* parent = 0);
   int nextId() const override;
+  // linked to by wizard
+  void handleMeepoFinished();
+  void handleMeepoFailed(bool using_google);
 
  protected:
   bool validatePage() override;
@@ -41,12 +44,8 @@ class ChromeoverLoginPage : public gondar::WizardPage {
  private:
   void showPressedButton();
   void showUnpressedButton();
-  void handleMeepoFinished();
-  void handleMeepoFailed(bool using_google);
   void handleGoogleSigninFinished(QNetworkReply* reply);
   void handleGoogleSigninFail();
-
-  gondar::Meepo meepo_;
 
   QGridLayout layout;
   QLineEdit usernameLineEdit;

--- a/src/download_progress_page.cc
+++ b/src/download_progress_page.cc
@@ -36,6 +36,8 @@ void DownloadProgressPage::initializePage() {
   manager.append(url.toString());
   connect(&manager, &DownloadManager::started, this,
           &DownloadProgressPage::onDownloadStarted);
+  // allow the download manager to access session state in the wizard
+  manager.setWizard(wizard());
 }
 
 void DownloadProgressPage::onDownloadStarted() {

--- a/src/downloader.cc
+++ b/src/downloader.cc
@@ -24,6 +24,7 @@
 #include <QStringList>
 #include <QTimer>
 
+#include "gondarwizard.h"
 #include "log.h"
 #include "metric.h"
 
@@ -83,7 +84,7 @@ void DownloadManager::startNextDownload() {
   }
 
   QNetworkRequest request(url);
-  gondar::SendMetric(gondar::Metric::DownloadAttempt);
+  gondar::SendMetric(wizard, gondar::Metric::DownloadAttempt);
   currentDownload = manager.get(request);
   connect(currentDownload, &QNetworkReply::finished, this,
           &DownloadManager::downloadFinished);
@@ -103,11 +104,11 @@ void DownloadManager::downloadFinished() {
     // download failed
     LOG_ERROR << "download failed: " << currentDownload->errorString();
     error = true;
-    gondar::SendMetric(gondar::Metric::DownloadFailure);
+    gondar::SendMetric(wizard, gondar::Metric::DownloadFailure);
   } else {
     LOG_INFO << "download succeeded";
     ++downloadedCount;
-    gondar::SendMetric(gondar::Metric::DownloadSuccess);
+    gondar::SendMetric(wizard, gondar::Metric::DownloadSuccess);
   }
 
   currentDownload->deleteLater();
@@ -128,4 +129,8 @@ QFileInfo DownloadManager::outputFileInfo() const {
 
 bool DownloadManager::hasError() {
   return error;
+}
+
+void DownloadManager::setWizard(GondarWizard* wizard_in) {
+  wizard = wizard_in;
 }

--- a/src/downloader.h
+++ b/src/downloader.h
@@ -60,6 +60,8 @@
 #include <QTime>
 #include <QUrl>
 
+class GondarWizard;
+
 class DownloadManager : public QObject {
   Q_OBJECT
 
@@ -73,6 +75,8 @@ class DownloadManager : public QObject {
 
   QFileInfo outputFileInfo() const;
   bool hasError();
+  // allow downloader to access wizard state
+  void setWizard(GondarWizard* wizard_in);
 
  signals:
   void started();
@@ -89,6 +93,7 @@ class DownloadManager : public QObject {
   QNetworkReply* currentDownload;
   QFile output;
   QTime downloadTime;
+  GondarWizard* wizard;
 
   bool error;
   int downloadedCount;

--- a/src/feedback_dialog.cc
+++ b/src/feedback_dialog.cc
@@ -19,6 +19,7 @@
 #include <QJsonDocument>
 #include <stdexcept>
 
+#include "gondarwizard.h"
 #include "log.h"
 #include "metric.h"
 #include "util.h"
@@ -45,6 +46,13 @@ FeedbackDialog::FeedbackDialog() {
   setWindowTitle(tr("CloudReady USB Maker"));
   // submit button initially grayed out, there's no input yet
   submit_button_.setEnabled(false);
+  wizard = NULL;
+}
+
+// allow the feedback widget to access the wizard similar
+// to the way wizard pages do
+void FeedbackDialog::setWizard(GondarWizard* wizard_in) {
+  wizard = wizard_in;
 }
 
 static QNetworkRequest createFeedbackRequest() {
@@ -87,7 +95,10 @@ void FeedbackDialog::submit() {
   QJsonObject json;
   json["feedback"] = feedback_field_.toPlainText();
   json["uuid"] = gondar::GetUuid();
-  json["site"] = gondar::GetSiteId();
+  // wizard may not be well-initialized
+  if (wizard != NULL) {
+    json["site"] = wizard->getSiteId();
+  }
   if (gondar::isChromeover()) {
     json["product"] = "chromeover";
   } else {

--- a/src/feedback_dialog.h
+++ b/src/feedback_dialog.h
@@ -25,6 +25,8 @@
 #include <QTextEdit>
 #include <QVBoxLayout>
 
+class GondarWizard;
+
 namespace gondar {
 
 class FeedbackDialog : public QDialog {
@@ -32,6 +34,8 @@ class FeedbackDialog : public QDialog {
 
  public:
   FeedbackDialog();
+  // allow this widget to access the wizard state like a wizard page
+  void setWizard(GondarWizard* wizard_in);
   void submit();
   void maybeEnableSubmit();
 
@@ -42,6 +46,7 @@ class FeedbackDialog : public QDialog {
   QNetworkAccessManager network_manager_;
   QPushButton submit_button_;
   QVBoxLayout layout_;
+  GondarWizard* wizard;
 };
 }  // namespace gondar
 

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -19,6 +19,7 @@
 
 #include "about_dialog.h"
 #include "admin_check_page.h"
+#include "chromeover_login_page.h"
 #include "device_select_page.h"
 #include "error_page.h"
 #include "feedback_dialog.h"
@@ -38,6 +39,7 @@ class GondarWizard::Private {
 
   AdminCheckPage adminCheckPage;
   DeviceSelectPage deviceSelectPage;
+  ChromeoverLoginPage chromeoverLoginPage;
   SiteSelectPage siteSelectPage;
   ErrorPage errorPage;
 
@@ -64,7 +66,7 @@ void GondarWizard::init() {
   setPage(Page_adminCheck, &p_->adminCheckPage);
   // chromeoverLogin and imageSelect are alternatives to each other
   // that both progress to usbInsertPage
-  setPage(Page_chromeoverLogin, &chromeoverLoginPage);
+  setPage(Page_chromeoverLogin, &p_->chromeoverLoginPage);
   setPage(Page_siteSelect, &p_->siteSelectPage);
   setPage(Page_imageSelect, &imageSelectPage);
   setPage(Page_usbInsert, &usbInsertPage);
@@ -94,9 +96,9 @@ void GondarWizard::init() {
 
   // wizard is responsible for this connection as wizard() is not callable
   // at construction time
-  connect(&meepo_, &gondar::Meepo::finished, &chromeoverLoginPage,
+  connect(&meepo_, &gondar::Meepo::finished, &p_->chromeoverLoginPage,
           &ChromeoverLoginPage::handleMeepoFinished);
-  connect(&meepo_, &gondar::Meepo::failed, &chromeoverLoginPage,
+  connect(&meepo_, &gondar::Meepo::failed, &p_->chromeoverLoginPage,
           &ChromeoverLoginPage::handleMeepoFailed);
 
   p_->runTime = QDateTime::currentDateTime();

--- a/src/gondarwizard.cc
+++ b/src/gondarwizard.cc
@@ -93,7 +93,6 @@ void GondarWizard::init() {
   // latest beerover url
   connect(&newestImageUrl, &NewestImageUrl::errorOccurred, this,
           &GondarWizard::handleNewestImageUrlError);
-
   // wizard is responsible for this connection as wizard() is not callable
   // at construction time
   connect(&meepo_, &gondar::Meepo::finished, &p_->chromeoverLoginPage,
@@ -101,8 +100,9 @@ void GondarWizard::init() {
   connect(&meepo_, &gondar::Meepo::failed, &p_->chromeoverLoginPage,
           &ChromeoverLoginPage::handleMeepoFailed);
 
-  p_->runTime = QDateTime::currentDateTime();
+  p_->feedbackDialog.setWizard(this);
 
+  p_->runTime = QDateTime::currentDateTime();
   p_->updateCheck.start(this);
 
   // resize the window (width, height)
@@ -204,4 +204,12 @@ bool GondarWizard::newestIsReady() {
 
 void GondarWizard::handleNewestImageUrlError() {
   postError("An error has occurred fetching the latest image");
+}
+
+int GondarWizard::getSiteId() {
+  return meepo_.getSiteId();
+}
+
+void GondarWizard::setSiteId(int site_id_in) {
+  meepo_.setSiteId(site_id_in);
 }

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -73,6 +73,8 @@ class GondarWizard : public QWizard {
   bool newestIsReady();
   void maybe_fetch();
   void handleNewestImageUrlError();
+  int getSiteId();
+  void setSiteId(int site_id_in);
 
   // this enum determines page order
   enum {

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -22,9 +22,11 @@
 #include <memory>
 #include <vector>
 
+#include "chromeover_login_page.h"
 #include "device_picker.h"
 #include "download_progress_page.h"
 #include "image_select_page.h"
+#include "meepo.h"
 #include "newest_image_url.h"
 #include "usb_insert_page.h"
 #include "write_operation_page.h"
@@ -60,6 +62,9 @@ class GondarWizard : public QWizard {
   UsbInsertPage usbInsertPage;
   WriteOperationPage writeOperationPage;
   NewestImageUrl newestImageUrl;
+  ChromeoverLoginPage chromeoverLoginPage;
+
+  gondar::Meepo meepo_;
 
   const std::vector<GondarSite>& sites() const;
   void setSites(const std::vector<GondarSite>& sites);

--- a/src/gondarwizard.h
+++ b/src/gondarwizard.h
@@ -22,7 +22,6 @@
 #include <memory>
 #include <vector>
 
-#include "chromeover_login_page.h"
 #include "device_picker.h"
 #include "download_progress_page.h"
 #include "image_select_page.h"
@@ -62,7 +61,6 @@ class GondarWizard : public QWizard {
   UsbInsertPage usbInsertPage;
   WriteOperationPage writeOperationPage;
   NewestImageUrl newestImageUrl;
-  ChromeoverLoginPage chromeoverLoginPage;
 
   gondar::Meepo meepo_;
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -32,7 +32,7 @@ int main(int argc, char* argv[]) {
 #endif
   Q_INIT_RESOURCE(gondarwizard);
   gondar::InitializeLogging();
-  gondar::SendMetric(gondar::Metric::Use);
+  gondar::SendMetricGondar(gondar::Metric::Use);
 #if defined(Q_OS_WIN)
   // dismiss Windows 'format disk' popups
   // placed here to enable logging for this step

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -313,10 +313,11 @@ QString Meepo::getMetricJson(std::string metric, std::string value) {
   QString description_string =
       QString("version=%1,value=%2").arg(version_string).arg(value_string);
   inner_json.insert("description", description_string);
-  // note that for meepo, currently we will always hit this case
-  // but a day may come when we add stuff like this to beerover, so
-  // there's no harm in adding a guard here
-  if (isChromeover() && site_id != 0) {
+  // removed explicit isChromeover() check here for tests
+  // because we already only send on non-zero site id, it was somewhat
+  // redundant to also check for chromeover.  also currently beerover
+  // has no meepo interaction so meaning of this case was not clear
+  if (site_id != 0) {
     inner_json.insert("site_id", site_id);
   }
   json["activity"] = inner_json;

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -31,6 +31,7 @@
 
 namespace {
 
+const char path_activity[] = "/activity";
 const char path_auth[] = "/auth";
 const char path_google_auth[] = "/google-auth";
 const char path_sites[] = "/sites";
@@ -287,14 +288,16 @@ void Meepo::handleDownloadsReply(QNetworkReply* reply) {
 }
 
 void Meepo::sendMetric(std::string metric, std::string value) {
-  auto url = createUrl("/activity");
+  auto url = createUrl(path_activity);
   QUrlQuery query;
   query.addQueryItem("token", api_token_);
   url.setQuery(query);
   QJsonObject json;
   QJsonObject inner_json;
 
-  inner_json.insert("activity", QString::fromStdString(metric));
+  QString activity_string =
+      QString("usb-maker-%1").arg(QString::fromStdString(metric));
+  inner_json.insert("activity", activity_string);
   // meepo already knows the site.
   // description should become a combination of gondar version and value if it
   // exists

--- a/src/meepo.cc
+++ b/src/meepo.cc
@@ -307,7 +307,8 @@ void Meepo::sendMetric(std::string metric, std::string value) {
   if (value_string.length() == 0) {
     value_string = none_string;
   }
-  QString description_string = QString("version=%1,value=%2").arg(version_string).arg(value_string);
+  QString description_string =
+      QString("version=%1,value=%2").arg(version_string).arg(value_string);
   inner_json.insert("description", description_string);
   const auto siteId = GetSiteId();
   // note that for meepo, currently we will always hit this case

--- a/src/meepo.h
+++ b/src/meepo.h
@@ -41,13 +41,20 @@ class Meepo : public QObject {
   void startGoogle(const QString id_token);
   // whether we have a token
   bool hasToken();
+  // just used by tests
+  void setToken(QString token_in);
+  // used by sendMetric and tests
+  QString getMetricJson(std::string metric, std::string value);
+  QNetworkRequest getMetricRequest();
+  // send a metric to meepo
   void sendMetric(std::string metric, std::string value);
-
   QString error() const;
   Sites sites() const;
   const QString no_sites_error =
       "User has no sites.  Please visit <a "
       "href=\"https://try.neverware.com\">try.neverware.com</a> for a trial.";
+  int getSiteId();
+  void setSiteId(int site_id_in);
 
  signals:
   void finished();
@@ -83,6 +90,8 @@ class Meepo : public QObject {
   // whether or not the user is currently authenticating using
   // 'sign in with google'
   bool google_mode_ = false;
+  // the site for our images, if selected, 0 otherwise
+  int site_id;
 };
 
 }  // namespace gondar

--- a/src/meepo.h
+++ b/src/meepo.h
@@ -39,6 +39,9 @@ class Meepo : public QObject {
   // finished() signal to get the results (including errors).
   void start(const QAuthenticator& auth);
   void startGoogle(const QString id_token);
+  // whether we have a token
+  bool hasToken();
+  void sendMetric(std::string metric, std::string value);
 
   QString error() const;
   Sites sites() const;
@@ -60,6 +63,8 @@ class Meepo : public QObject {
 
   void requestDownloads(const GondarSite& site);
   void handleDownloadsReply(QNetworkReply* reply);
+
+  void handleMetricsReply(QNetworkReply* reply);
 
   void dispatchReply(QNetworkReply* reply);
   void fail(const QString& error);

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -22,10 +22,12 @@
 #include <QNetworkRequest>
 #include <QStandardPaths>
 #include <QUrl>
+#include <QUrlQuery>
 #include <QUuid>
 
 #include "config.h"
 #include "log.h"
+#include "meepo.h"
 #include "util.h"
 
 namespace gondar {
@@ -108,6 +110,9 @@ QString GetUuid() {
 
 // the metrics layer stores the site id to provide in later metrics
 // once it is available
+// TODO(ken): now that the metrics layer is passed a wizard instance
+// there is no real reason to have static state just for site_id
+// OVER-11807
 namespace {
 static int site_id = 0;
 }
@@ -120,13 +125,23 @@ int GetSiteId() {
   return site_id;
 }
 
-void SendMetric(Metric metric, const std::string& value) {
+static bool shouldSendMetrics() {
   const auto api_key = getMetricsApiKey();
   if (api_key.isEmpty()) {
     // all production builds should sent metrics
     LOG_WARNING << "not sending metrics!";
+    return false;
+  }
+  return true;
+}
+
+// send regular gondar metrics
+void SendMetricGondar(Metric metric, const std::string& value) {
+  if (!shouldSendMetrics()) {
     return;
   }
+  LOG_INFO << "sending a Klassic Metric: " << getMetricString(metric);
+  const auto api_key = getMetricsApiKey();
   std::string metricStr = getMetricString(metric);
   QNetworkAccessManager* manager = getNetworkManager();
   QUrl url("https://gondar-metrics.neverware.com/prod");
@@ -161,5 +176,26 @@ void SendMetric(Metric metric, const std::string& value) {
   QJsonDocument doc(json);
   QString strJson(doc.toJson(QJsonDocument::Compact));
   manager->post(request, QByteArray(strJson.toUtf8()));
+}
+
+static void SendMetricMeepo(Metric metric,
+                            const std::string& value,
+                            GondarWizard* wizard) {
+  // don't send metrics to meepo if we're not configured to send metrics
+  // technically we could, but for simplicity all metrics will be on/off
+  // together.
+  if (!shouldSendMetrics()) {
+    return;
+  }
+  LOG_INFO << "sending a Meepo Metric: " << getMetricString(metric);
+  wizard->meepo_.sendMetric(getMetricString(metric), value);
+}
+
+void SendMetric(GondarWizard* wizard, Metric metric, const std::string& value) {
+  SendMetricGondar(metric, value);
+  // if we have a token, also send the metric to meepo
+  if (wizard && wizard->meepo_.hasToken()) {
+    SendMetricMeepo(metric, value, wizard);
+  }
 }
 }  // namespace gondar

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -108,23 +108,6 @@ QString GetUuid() {
   return id;
 }
 
-// the metrics layer stores the site id to provide in later metrics
-// once it is available
-// TODO(ken): now that the metrics layer is passed a wizard instance
-// there is no real reason to have static state just for site_id
-// OVER-11807
-namespace {
-static int site_id = 0;
-}
-
-void SetSiteId(int site_id_in) {
-  site_id = site_id_in;
-}
-
-int GetSiteId() {
-  return site_id;
-}
-
 static bool shouldSendMetrics() {
   const auto api_key = getMetricsApiKey();
   if (api_key.isEmpty()) {
@@ -136,7 +119,7 @@ static bool shouldSendMetrics() {
 }
 
 // send regular gondar metrics
-void SendMetricGondar(Metric metric, const std::string& value) {
+void SendMetricGondar(Metric metric, const std::string& value, int site_id) {
   if (!shouldSendMetrics()) {
     return;
   }
@@ -164,10 +147,10 @@ void SendMetricGondar(Metric metric, const std::string& value) {
     product = "beerover";
   }
   json.insert("product", product);
-  const auto siteId = GetSiteId();
+  // const auto siteId = GetSiteId();
   // only show site when on chromeover and site id has been initialized
-  if (isChromeover() && siteId != 0) {
-    json.insert("site", siteId);
+  if (isChromeover() && site_id != 0) {
+    json.insert("site", site_id);
   }
   QNetworkRequest request(url);
   request.setRawHeader(QByteArray("x-api-key"), api_key);
@@ -192,7 +175,7 @@ static void SendMetricMeepo(Metric metric,
 }
 
 void SendMetric(GondarWizard* wizard, Metric metric, const std::string& value) {
-  SendMetricGondar(metric, value);
+  SendMetricGondar(metric, value, wizard->getSiteId());
   // if we have a token, also send the metric to meepo
   if (wizard && wizard->meepo_.hasToken()) {
     SendMetricMeepo(metric, value, wizard);

--- a/src/metric.h
+++ b/src/metric.h
@@ -19,6 +19,8 @@
 #include <QString>
 #include <string>
 
+#include "gondarwizard.h"
+
 namespace gondar {
 
 enum class Metric {
@@ -38,7 +40,12 @@ enum class Metric {
 
 void SetSiteId(int site_id);
 
-void SendMetric(Metric metric, const std::string& value = "");
+// send a metric just to gondar endpoint, not both gondar and meepo
+void SendMetricGondar(Metric metric, const std::string& value = "");
+// send a metric to gondar endpoint and meepo endpoint if we have a session
+void SendMetric(GondarWizard* wizard,
+                Metric metric,
+                const std::string& value = "");
 
 QString GetUuid();
 int GetSiteId();

--- a/src/metric.h
+++ b/src/metric.h
@@ -38,18 +38,16 @@ enum class Metric {
   Use,
 };
 
-void SetSiteId(int site_id);
-
 // send a metric just to gondar endpoint, not both gondar and meepo
-void SendMetricGondar(Metric metric, const std::string& value = "");
+void SendMetricGondar(Metric metric,
+                      const std::string& value = "",
+                      int site_id = 0);
 // send a metric to gondar endpoint and meepo endpoint if we have a session
 void SendMetric(GondarWizard* wizard,
                 Metric metric,
                 const std::string& value = "");
 
 QString GetUuid();
-int GetSiteId();
-
 }  // namespace gondar
 
 #endif  // SRC_METRIC_H_

--- a/src/site_select_page.cc
+++ b/src/site_select_page.cc
@@ -66,7 +66,7 @@ bool SiteSelectPage::validatePage() {
   } else {
     const auto site = selected->site();
     // metrics may now include site id
-    gondar::SetSiteId(site.getSiteId());
+    wizard()->setSiteId(site.getSiteId());
     QList<GondarImage> imageList = site.getImages();
     wizard()->imageSelectPage.addImages(imageList);
     return true;

--- a/src/write_operation_page.cc
+++ b/src/write_operation_page.cc
@@ -77,12 +77,12 @@ void WriteOperationPage::writeToDrive() {
   if (wizard()->isFormatOnly()) {
     // make a disk write thread in format mode
     diskWriteThread = new DiskWriteThread(&device, this);
-    gondar::SendMetric(gondar::Metric::FormatAttempt);
+    gondar::SendMetric(wizard(), gondar::Metric::FormatAttempt);
   } else {
     image_path.clear();
     image_path.append(wizard()->downloadProgressPage.getImageFileName());
     diskWriteThread = new DiskWriteThread(&device, image_path, this);
-    gondar::SendMetric(gondar::Metric::UsbAttempt);
+    gondar::SendMetric(wizard(), gondar::Metric::UsbAttempt);
   }
   connect(diskWriteThread, &DiskWriteThread::finished, this,
           &WriteOperationPage::onDoneWriting);
@@ -162,12 +162,12 @@ void WriteOperationPage::onDoneWriting() {
   progress.setRange(0, 100);
   progress.setValue(100);
   if (wizard()->isFormatOnly()) {
-    gondar::SendMetric(gondar::Metric::FormatSuccess);
+    gondar::SendMetric(wizard(), gondar::Metric::FormatSuccess);
   } else {
     wizard()->setMakeAnotherLayout();
-    gondar::SendMetric(gondar::Metric::UsbSuccess);
+    gondar::SendMetric(wizard(), gondar::Metric::UsbSuccess);
     // when a USB was successfully created, report time the run took
-    gondar::SendMetric(gondar::Metric::SuccessDuration,
+    gondar::SendMetric(wizard(), gondar::Metric::SuccessDuration,
                        QString::number(wizard()->getRunTime()).toStdString());
   }
   emit completeChanged();

--- a/test/test.cc
+++ b/test/test.cc
@@ -83,7 +83,7 @@ void Test::testMeepoGetMetricJson() {
   // then we test the url against expected for our meepo's state
   QString metric_json = meepo.getMetricJson("kewlmetric", "kewlvalue");
   QString expected = expected_doc.toJson(QJsonDocument::Compact);
-  QCOMPARE(expected, metric_json);
+  QCOMPARE(metric_json, expected);
 }
 
 // currently this just tests that the url is as expected
@@ -93,7 +93,7 @@ void Test::testMeepoGetMetricRequest() {
   auto expected_url =
       QUrl("https://api.grv.neverware.com/poof/activity?token=kewltok2");
   QNetworkRequest actual_request = meepo.getMetricRequest();
-  QCOMPARE(expected_url, actual_request.url());
+  QCOMPARE(actual_request.url(), expected_url);
 }
 
 }  // namespace gondar

--- a/test/test.cc
+++ b/test/test.cc
@@ -16,8 +16,15 @@
 #include "test.h"
 
 #include <QAbstractButton>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QNetworkRequest>
+#include <QUrl>
 
 #include "src/device_picker.h"
+#include "src/log.h"
+#include "src/meepo.h"
 
 #if defined(Q_OS_WIN)
 Q_IMPORT_PLUGIN(QWindowsIntegrationPlugin);
@@ -61,6 +68,31 @@ void Test::testDevicePicker() {
   btn->click();
 
   QCOMPARE(*picker.selectedDevice(), DeviceGuy(3, "c", getValidDiskSize()));
+}
+
+void Test::testMeepoGetMetricJson() {
+  Meepo meepo;
+  meepo.setSiteId(3);
+  meepo.setToken(QString("kewltok"));
+  // then we test the json against expected for our meepo's state
+  QString expected_json_str =
+      "{\"activity\":{\"activity\":\"usb-maker-kewlmetric\",\"description\":"
+      "\"version=none,value=kewlvalue\",\"site_id\":3}}";
+  QJsonDocument expected_doc =
+      QJsonDocument::fromJson(expected_json_str.toUtf8());
+  // then we test the url against expected for our meepo's state
+  QString metric_json = meepo.getMetricJson("kewlmetric", "kewlvalue");
+  QString expected = expected_doc.toJson(QJsonDocument::Compact);
+  QCOMPARE(expected, metric_json);
+}
+
+// currently this just tests that the url is as expected
+void Test::testMeepoGetMetricRequest() {
+  Meepo meepo;
+  meepo.setToken(QString("kewltok2"));
+  auto expected_url = QUrl("https://api.grv.neverware.com/poof/activity?token=kewltok2");
+  QNetworkRequest actual_request = meepo.getMetricRequest();
+  QCOMPARE(expected_url, actual_request.url());
 }
 
 }  // namespace gondar

--- a/test/test.cc
+++ b/test/test.cc
@@ -90,7 +90,8 @@ void Test::testMeepoGetMetricJson() {
 void Test::testMeepoGetMetricRequest() {
   Meepo meepo;
   meepo.setToken(QString("kewltok2"));
-  auto expected_url = QUrl("https://api.grv.neverware.com/poof/activity?token=kewltok2");
+  auto expected_url =
+      QUrl("https://api.grv.neverware.com/poof/activity?token=kewltok2");
   QNetworkRequest actual_request = meepo.getMetricRequest();
   QCOMPARE(expected_url, actual_request.url());
 }

--- a/test/test.h
+++ b/test/test.h
@@ -26,6 +26,8 @@ class Test : public QObject {
 
  private slots:
   void testDevicePicker();
+  void testMeepoGetMetricJson();
+  void testMeepoGetMetricRequest();
 };
 }  // namespace gondar
 


### PR DESCRIPTION
Note that this PR includes a rework to move some newly-shared functionality up to the wizard-level out of individual pages.

Currently the "description" field includes version and value fields, as meepo appears to be able to infer everything else from the token such as site.

Addresses OVER-8821